### PR TITLE
fixed: coffeescript auto-register extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
-require('coffee-script')
+require('coffee-script/register')
 require(__dirname+"/cofmon.coffee")


### PR DESCRIPTION
coffeescript doesn't autoregister itself anymore, so your code doesn't work because it's interpreted as js.
requiring coffescript/register solves this.
